### PR TITLE
CheckBox validationCheckBox

### DIFF
--- a/app/src/main/java/uek/krakow/pl/androidinvoicegenerator/viewcontroller/SettingsActivity.java
+++ b/app/src/main/java/uek/krakow/pl/androidinvoicegenerator/viewcontroller/SettingsActivity.java
@@ -6,6 +6,7 @@ import android.content.SharedPreferences;
 import android.support.v7.app.AlertDialog;
 import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
+import android.util.Log;
 import android.view.View;
 import android.widget.ArrayAdapter;
 import android.widget.Button;
@@ -25,7 +26,7 @@ public class SettingsActivity extends AppCompatActivity {
 
     private Button styleButton;
     private Button remoteStyleButton;
-    private CheckBox validationCheckBox;
+//    private CheckBox validationCheckBox;
     private EditText styleNameText;
     private ListView listView;
 
@@ -48,13 +49,14 @@ public class SettingsActivity extends AppCompatActivity {
         adapter.notifyDataSetChanged();
     }
 
+
     @Override
     protected void onPause() {
         super.onPause();
 
-        SharedPreferences sharedPreferences = getPreferences(Context.MODE_PRIVATE);
-        SharedPreferences.Editor editor = sharedPreferences.edit();
-        editor.putBoolean("validation", validationCheckBox.isChecked());
+//        SharedPreferences sharedPreferences = getPreferences(Context.MODE_PRIVATE);
+//        SharedPreferences.Editor editor = sharedPreferences.edit();
+//        editor.putBoolean("validation", validationCheckBox.isChecked());
     }
 
     public void wymazDostawce(View view) {


### PR DESCRIPTION
When the back button is pressed, it calls onPause() which called
"editor.putBoolean("validation", validationCheckBox.isChecked()) ".
Since CheckBox was never assigned a value/instantiated, it's null.
Checking against the null value generated the nullPointErrorException.
So I commented it out until the ChcekBox widget finds a purpose.  Thanks